### PR TITLE
出品ボタン修正

### DIFF
--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -108,10 +108,10 @@
             .right_bar_2
         .submit-button
           .actions
-            - if action_name == "new"
-              =f.submit "出品する",class:"btn--red"
-            - else
+            - if (action_name == "edit") || @product.id.present?
               =f.submit "更新する",class:"btn--red"
+            - else
+              =f.submit "出品する",class:"btn--red"
           =link_to "もどる",products_path,class:"btn--gray"
         .prohibition
           %p.prohibition__action


### PR DESCRIPTION
## What
出品ボタン修正

## Why
出品に失敗した時、出品ボタンの文字が更新ボタンになっていた為。